### PR TITLE
Update test code - inconclusive

### DIFF
--- a/cpaplib_tests/PRS1_tests.cs
+++ b/cpaplib_tests/PRS1_tests.cs
@@ -98,7 +98,12 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanImportFromRootFolder()
 	{
-		var loader = new PRS1DataLoader();
+        if (!File.Exists(SD_CARD_ROOT))
+        {
+            Assert.Inconclusive($"Test path '{SD_CARD_ROOT}' does not exist.");
+        }
+
+        var loader = new PRS1DataLoader();
 		Assert.IsTrue( loader.HasCorrectFolderStructure( SD_CARD_ROOT ) );
 		Assert.IsNotNull( loader.LoadMachineIdentificationInfo( SD_CARD_ROOT ) );
 		
@@ -110,14 +115,23 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanImportDateRangeOnly()
 	{
+        if (!File.Exists(SD_CARD_ROOT))
+        {
+            Assert.Inconclusive($"Test path '{SD_CARD_ROOT}' does not exist.");
+        }
+        
 		var loader = new PRS1DataLoader();
 		Assert.IsTrue( loader.HasCorrectFolderStructure( SD_CARD_ROOT ) );
 		Assert.IsNotNull( loader.LoadMachineIdentificationInfo( SD_CARD_ROOT ) );
 
 		var propertyFilePath = Path.Combine( SOURCE_FOLDER, "Properties.txt" );
-		Assert.IsTrue( File.Exists( propertyFilePath ) );
 
-		var fields     = ReadKeyValueFile( propertyFilePath );
+        if (!File.Exists(propertyFilePath))
+        {
+            Assert.Inconclusive($"Test path '{propertyFilePath}' does not exist.");
+        }
+
+        var fields     = ReadKeyValueFile( propertyFilePath );
 		var firstDate  = DateTime.UnixEpoch.AddSeconds( int.Parse( fields[ "FirstDate" ] ) ).ToLocalTime().Date;
 		var lastDate   = DateTime.UnixEpoch.AddSeconds( int.Parse( fields[ "LastDate" ] ) ).ToLocalTime().Date;
 		
@@ -135,9 +149,13 @@ public class PRS1_tests
 	public void PropertiesFileExistsAndCanBeParsed()
 	{
 		var propertyFilePath = Path.Combine( SOURCE_FOLDER, "Properties.txt" );
-		Assert.IsTrue( File.Exists( propertyFilePath ) );
 
-		var fields = ReadKeyValueFile( propertyFilePath );
+        if (!File.Exists(propertyFilePath))
+        {
+            Assert.Inconclusive($"Test path '{propertyFilePath}' does not exist.");
+        }
+
+        var fields = ReadKeyValueFile( propertyFilePath );
 
 		Assert.AreEqual( fields[ "SerialNumber" ],     "P1192913945CE" );
 		Assert.AreEqual( fields[ "ModelNumber" ],      "560P" );
@@ -161,7 +179,11 @@ public class PRS1_tests
 	public void PatientFolderExists()
 	{
 		var propertyFilePath = Path.Combine( SOURCE_FOLDER, "Properties.txt" );
-		Assert.IsTrue( File.Exists( propertyFilePath ) );
+
+        if (!File.Exists(propertyFilePath))
+        {
+            Assert.Inconclusive($"Test path '{propertyFilePath}' does not exist.");
+        }
 
 		var fields            = ReadKeyValueFile( propertyFilePath );
 		var patientFolderPath = Path.Combine( SOURCE_FOLDER, $"p{fields[ "PatientFolderNum" ]}" );
@@ -179,9 +201,13 @@ public class PRS1_tests
 	public void CanReadDataFileHeader()
 	{
 		var propertyFilePath = Path.Combine( SOURCE_FOLDER, "Properties.txt" );
-		Assert.IsTrue( File.Exists( propertyFilePath ) );
 
-		var fields            = ReadKeyValueFile( propertyFilePath );
+        if (!File.Exists(propertyFilePath))
+        {
+            Assert.Inconclusive($"Test path '{propertyFilePath}' does not exist.");
+        }
+
+        var fields            = ReadKeyValueFile( propertyFilePath );
 		var patientFolderPath = Path.Combine( SOURCE_FOLDER, $"p{fields[ "PatientFolderNum" ]}" );
 		var dataFiles         = Directory.GetFiles( patientFolderPath, "*.00?" );
 
@@ -211,7 +237,12 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanReadSummaryFileChunks()
 	{
-		var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.001", SearchOption.AllDirectories );
+        if (!File.Exists(SOURCE_FOLDER))
+        {
+            Assert.Inconclusive($"Test path '{SOURCE_FOLDER}' does not exist.");
+        }
+
+        var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.001", SearchOption.AllDirectories );
 
 		foreach( var filename in dataFiles )
 		{
@@ -233,7 +264,12 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanSerializeAndDeserializeSettings()
 	{
-		var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.001", SearchOption.AllDirectories );
+        if (!File.Exists(SOURCE_FOLDER))
+        {
+            Assert.Inconclusive($"Test path '{SOURCE_FOLDER}' does not exist.");
+        }
+
+        var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.001", SearchOption.AllDirectories );
 
 		foreach( var filename in dataFiles )
 		{
@@ -278,7 +314,12 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanReadEventFileChunks()
 	{
-		var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.002", SearchOption.AllDirectories );
+        if (!File.Exists(SOURCE_FOLDER))
+        {
+            Assert.Inconclusive($"Test path '{SOURCE_FOLDER}' does not exist.");
+        }
+
+        var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.002", SearchOption.AllDirectories );
 
 		foreach( var filename in dataFiles )
 		{
@@ -307,7 +348,12 @@ public class PRS1_tests
 	[TestMethod]
 	public void CanReadWaveformFileChunks()
 	{
-		var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.005", SearchOption.AllDirectories );
+        if (!File.Exists(SOURCE_FOLDER))
+        {
+            Assert.Inconclusive($"Test path '{SOURCE_FOLDER}' does not exist.");
+        }
+
+        var dataFiles = Directory.GetFiles( SOURCE_FOLDER, "*.005", SearchOption.AllDirectories );
 
 		foreach( var filename in dataFiles )
 		{

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -19,11 +19,11 @@ public class Scratchpad
     public void CanDetectDaylightSavingTime()
     {
         DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Utc);
-        var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        var isDaylightSavings = TimeZoneInfo.Utc.IsDaylightSavingTime(testDateTime);
         Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}." );
 
         testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Utc);
-        isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        isDaylightSavings = TimeZoneInfo.Utc.IsDaylightSavingTime(testDateTime);
         Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
     }
 

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -18,11 +18,11 @@ public class Scratchpad
     [TestMethod]
     public void CanDetectDaylightSavingTime()
     {
-        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
+        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Utc);
         var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}." );
 
-        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
+        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Utc);
         isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
     }

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -79,7 +79,10 @@ public class Scratchpad
 
         string path = @"D:\Data Files\Viatom\23072C0009\20231004031747";
 
-        Assert.IsTrue( File.Exists( path ) );
+        if (!File.Exists( path ))
+        {
+            Assert.Inconclusive($"Test path '{path}' does not exist.");
+        }
 
         using var file   = File.OpenRead( path );
         using var reader = new BinaryReader( file );

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -18,11 +18,11 @@ public class Scratchpad
     [TestMethod]
     public void CanDetectDaylightSavingTime()
     {
-        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0);
+        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
         var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}." );
 
-        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0);
+        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
         isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}.");
     }

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -18,13 +18,15 @@ public class Scratchpad
     [TestMethod]
     public void CanDetectDaylightSavingTime()
     {
-        var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime( new DateTime( 2024, 5, 15, 14, 31, 0 ) );
-        Assert.IsTrue( isDaylightSavings );
-        
-        isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime( new DateTime( 2024, 2, 15, 14, 31, 0 ) );
-        Assert.IsFalse( isDaylightSavings );
+        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0);
+        var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}." );
+
+        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0);
+        isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}.");
     }
-    
+
     [TestMethod]
     public void CanSerializeAndDeserializeNumberDictionary()
     {

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -18,12 +18,12 @@ public class Scratchpad
     [TestMethod]
     public void CanDetectDaylightSavingTime()
     {
-        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Utc);
-        var isDaylightSavings = TimeZoneInfo.Utc.IsDaylightSavingTime(testDateTime);
+        DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
+        var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}." );
 
-        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Utc);
-        isDaylightSavings = TimeZoneInfo.Utc.IsDaylightSavingTime(testDateTime);
+        testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
+        isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
         Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
     }
 

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -20,11 +20,11 @@ public class Scratchpad
     {
         DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
         var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
-        Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}." );
+        Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}." );
 
         testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
         isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
-        Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}', isDaylightSavings = {isDaylightSavings}.");
+        Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
     }
 
     [TestMethod]

--- a/cpaplib_tests/Scratchpad.cs
+++ b/cpaplib_tests/Scratchpad.cs
@@ -19,11 +19,11 @@ public class Scratchpad
     public void CanDetectDaylightSavingTime()
     {
         DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
-        var isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        var isDaylightSavings = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
         Assert.IsTrue( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}." );
 
         testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
-        isDaylightSavings = TimeZoneInfo.Local.IsDaylightSavingTime(testDateTime);
+        isDaylightSavings = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
         Assert.IsFalse( isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
     }
 


### PR DESCRIPTION
Make results inconclusive for tests which need a specific folder to exist, when that folder and/or drive is not available.