### PR TITLE
Centralize date IsDaylightSavingTime

### DIFF
--- a/cpap-app/cpap-app/Helpers/DateHelper.cs
+++ b/cpap-app/cpap-app/Helpers/DateHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using cpaplib;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace cpap_app.Helpers;
@@ -9,7 +10,7 @@ public static class DateHelper
 
 	public static DateTime AdjustForDaylightSavings( this DateTime dt )
 	{
-		if( TimeZoneInfo.Local.IsDaylightSavingTime( dt ) )
+		if(DateUtil.IsDaylightSavingTime( dt ) )
 		{
 			return dt + TimeSpan.FromHours( 1 );
 		}
@@ -69,8 +70,8 @@ public static class DateHelper
 	{
 		var result = UnixEpoch.AddMilliseconds( milliseconds );
 		
-		var resultIsDST = TimeZoneInfo.Local.IsDaylightSavingTime( result );
-		var nowIsDst    = TimeZoneInfo.Local.IsDaylightSavingTime( DateTime.Today );
+		var resultIsDST = DateUtil.IsDaylightSavingTime( result );
+		var nowIsDst    = DateUtil.IsDaylightSavingTime( DateTime.Today );
 		
 		// Compensate for ToLocalTime() being incorrect for some historical dates
 		return resultIsDST switch
@@ -92,8 +93,8 @@ public static class DateHelper
 	{
 		var result = UnixEpoch.AddMilliseconds( nanoseconds * 1E-6 );
 
-		var resultIsDST = TimeZoneInfo.Local.IsDaylightSavingTime( result );
-		var nowIsDst    = TimeZoneInfo.Local.IsDaylightSavingTime( DateTime.Today );
+		var resultIsDST = DateUtil.IsDaylightSavingTime( result );
+		var nowIsDst    = DateUtil.IsDaylightSavingTime( DateTime.Today );
 		
 		// Compensate for ToLocalTime() being incorrect for some historical dates
 		return resultIsDST switch

--- a/cpap-lib/CpapImportSettings.cs
+++ b/cpap-lib/CpapImportSettings.cs
@@ -95,7 +95,7 @@ namespace cpaplib
         /// </summary>
         public DateTime GetAdjustedTime( DateTime value )
         {
-            if( UseDaylightSavingsTime && TimeZoneInfo.Local.IsDaylightSavingTime( value ) )
+            if( UseDaylightSavingsTime && DateUtil.IsDaylightSavingTime( value ) )
             {
                 value += TimeSpan.FromHours( 1 );
             }            

--- a/cpap-lib/DateTimeExtensions.cs
+++ b/cpap-lib/DateTimeExtensions.cs
@@ -11,7 +11,7 @@ namespace cpaplib
         }
     }
 
-    internal static class DateUtil
+    public static class DateUtil
     {
         [MethodImpl( MethodImplOptions.AggressiveInlining )]
         public static DateTime Min( DateTime a, DateTime b )
@@ -23,6 +23,12 @@ namespace cpaplib
         public static DateTime Max( DateTime a, DateTime b )
         {
             return (a > b) ? a : b;
+        }
+
+        public static bool IsDaylightSavingTime(DateTime dateTime)
+        {
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.Local;
+            return timeZoneInfo.IsDaylightSavingTime(dateTime);
         }
     }
 

--- a/cpap-lib/DateTimeExtensions.cs
+++ b/cpap-lib/DateTimeExtensions.cs
@@ -27,7 +27,9 @@ namespace cpaplib
 
         public static bool IsDaylightSavingTime(DateTime dateTime)
         {
-            TimeZoneInfo timeZoneInfo = TimeZoneInfo.Local;
+            //TODO: Use the TZ of the PAP machine
+
+            TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
             return timeZoneInfo.IsDaylightSavingTime(dateTime);
         }
     }

--- a/cpaplib_tests/DateTimeTests.cs
+++ b/cpaplib_tests/DateTimeTests.cs
@@ -16,11 +16,11 @@ namespace cpaplib_tests
         public void CanDetectDaylightSavingTime()
         {
             DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
-            var isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime); //TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
+            var isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime);
             Assert.IsTrue(isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
 
             testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
-            isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime); //TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
+            isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime);
             Assert.IsFalse(isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
         }
 

--- a/cpaplib_tests/DateTimeTests.cs
+++ b/cpaplib_tests/DateTimeTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using cpap_app.Helpers;
+using cpaplib;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -14,11 +16,11 @@ namespace cpaplib_tests
         public void CanDetectDaylightSavingTime()
         {
             DateTime testDateTime = new(2024, 5, 15, 14, 31, 0, DateTimeKind.Local);
-            var isDaylightSavings = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
+            var isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime); //TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
             Assert.IsTrue(isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
 
             testDateTime = new DateTime(2024, 2, 15, 14, 31, 0, DateTimeKind.Local);
-            isDaylightSavings = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
+            isDaylightSavings = DateUtil.IsDaylightSavingTime(testDateTime); //TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time").IsDaylightSavingTime(testDateTime);
             Assert.IsFalse(isDaylightSavings, $"Date '{testDateTime}' ({testDateTime.Kind}), isDaylightSavings = {isDaylightSavings}.");
         }
 


### PR DESCRIPTION
Move all of the calls to IsDaylightSavingTime to a single utility method, and use a unit test to verify its accuracy.