### PR TITLE
Hide model number, add tooltip

### DIFF
--- a/cpap-app/cpap-app/Views/DailyDetailsView.axaml
+++ b/cpap-app/cpap-app/Views/DailyDetailsView.axaml
@@ -16,10 +16,16 @@
         <StackPanel Name="ViewContents">
             <StackPanel DataContext="{Binding MachineInfo}" Margin="4 8 0 0">
                 <TextBlock Theme="{DynamicResource BodyStrongTextBlockStyle}">
+					<ToolTip.Tip>
+						<TextBlock Theme="{DynamicResource BodyStrongTextBlockStyle}">
+							<Run>Model: </Run>
+							<Run Text="{Binding ModelNumber, Mode=OneWay}" />
+						</TextBlock>
+					</ToolTip.Tip>
                     <Run>Device: </Run>
                     <Run Text="{Binding ProductName, Mode=OneWay}" />
                 </TextBlock>
-                <TextBlock Theme="{DynamicResource BodyStrongTextBlockStyle}">
+                <TextBlock Theme="{DynamicResource BodyStrongTextBlockStyle}" Name="DeviceModelNumberLabel">
                     <Run>Model: </Run>
                     <Run Text="{Binding ModelNumber, Mode=OneWay}" />
                 </TextBlock>

--- a/cpap-app/cpap-app/Views/DailyDetailsView.axaml.cs
+++ b/cpap-app/cpap-app/Views/DailyDetailsView.axaml.cs
@@ -22,7 +22,9 @@ public partial class DailyDetailsView : UserControl
 	public DailyDetailsView()
 	{
 		InitializeComponent();
-	}
+		
+		DeviceModelNumberLabel.IsVisible = false; //TODO: Hook this up to a setting
+    }
 
 	protected override void OnPropertyChanged( AvaloniaPropertyChangedEventArgs change )
 	{


### PR DESCRIPTION
The code is set up to be conditional and may use a setting one day.  For now, it's gone from view and the info has been moved to a tool tip.

Closes #26 