### PR TITLE
Resmed 10 Autoset S.A.MinPress missing, so let's handle S.AS.MinPress

### DIFF
--- a/cpap-lib/ResMedDataLoader.cs
+++ b/cpap-lib/ResMedDataLoader.cs
@@ -1029,8 +1029,15 @@ namespace cpaplib
                 case OperatingMode.Cpap:
                     break;
                 case OperatingMode.Apap:
-                    settings[SettingNames.MinPressure] = data["S.A.MinPress"]; //data["S.AS.MinPress"];
-                    settings[SettingNames.MaxPressure] = data["S.A.MaxPress"]; //data["S.AS.MaxPress"];
+                    if (data.ContainsKey("S.A.MinPress"))
+                    {
+                        settings[SettingNames.MinPressure] = data["S.A.MinPress"];
+                        settings[SettingNames.MaxPressure] = data["S.A.MaxPress"];
+                    } else
+                    {
+                        settings[SettingNames.MinPressure] = data["S.AS.MinPress"];
+                        settings[SettingNames.MaxPressure] = data["S.AS.MaxPress"];
+                    }
                     break;
                 case OperatingMode.Asv:
                     settings[SettingNames.RampPressure] = data["S.AV.StartPress"];


### PR DESCRIPTION
Hello,

I have a 10 Autoset setup in auto mode. My files didn't load because S.A.MinPress doesn't exist, but looking at the comments it should be either that or S.AS.MinPress, so I put an if there. Settings looks to be correct for my device.

![image](https://github.com/user-attachments/assets/a82de328-d174-4eb1-94db-805db8fbe9f7)
