### PR TITLE
Fix:  Update culture if needed

### DIFF
--- a/cpap-db/ColumnMapping.cs
+++ b/cpap-db/ColumnMapping.cs
@@ -77,7 +77,7 @@ public class ColumnMapping
 	public IBlobTypeConverter Converter { get; set; }
 
 	private PropertyInfo _property;
-	private System.Type  _propertyType
+	private System.Type _propertyType;
 	private static CultureInfo _operatingCulture;
 
     public ColumnMapping( string columnName, string propertyName, Type owningType )


### PR DESCRIPTION
Fix startup crash by explicitly defining the numeric parsing rules necessary.